### PR TITLE
[fix]: rename player.gd file to Player.gd

### DIFF
--- a/player.tscn
+++ b/player.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=17 format=3 uid="uid://xcjrjq5cbn7y"]
 
-[ext_resource type="Script" path="res://player.gd" id="1_2v3wm"]
+[ext_resource type="Script" path="res://Player.gd" id="1_2v3wm"]
 [ext_resource type="PackedScene" uid="uid://cf1dcxwv6bvl3" path="res://models/Pistol.glb" id="2_4esil"]
 [ext_resource type="Texture2D" uid="uid://vwob30tkwej4" path="res://addons/kenney_particle_pack/star_06.png" id="3_27dhu"]
 


### PR DESCRIPTION
Just a suggestion. I am not 100% sure this is the exact fix, but I did notice the capitalization here changed since I got an error when running in headless mode with this command:

![image](https://user-images.githubusercontent.com/6545465/216780870-cb54ca85-36a8-4d56-8dcd-efc9e797cea7.png)


```
./Godot_v4.0-beta17_linux.x86_64 --main-pack shoot.pck --headless
Godot Engine v4.0.beta17.official.c40020513 - https://godotengine.org
```